### PR TITLE
chore: add .nvmrc (lts/erbium)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium


### PR DESCRIPTION
Dodaje `.nvmrc` z `lts/erbium`.

dopasowane do engines '>=12' (Node 12).

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.